### PR TITLE
Add accessible descriptions of the current map view.

### DIFF
--- a/example/bike-philly/config.js
+++ b/example/bike-philly/config.js
@@ -14,6 +14,7 @@ var config = {
             title: 'Philadelphia Bicycle Infrastructure',
             image: '',
             description: 'Getting around Philadelphia on two wheels is fast, fun, and cheap. As a typical East Coast large city, the urban core is dense, so there is a lot within reach of a 15 minute ride... even mountain bike trails. Paired with the public transit infrastructure, cycling can be more efficient and much less expensive than driving (and parking) a car.',
+            mapDescription: 'Overview of Philadelphia showing bike lanes in green and city limits highlighted.',
             location: {
                 center: [-75.13080, 39.97790],
                 zoom: 9.83,
@@ -39,6 +40,7 @@ var config = {
             title: 'Bike Lanes',
             image: '',
             description: 'Philadelphia has XX miles of bike lanes, XX miles of which are protected. Drivers are getting more used to sharing the road, but ride defensively.',
+            mapDescription: 'Zoomed in and oblique view of the bike lanes of Philadelphia which are highlighted in green',
             location: {
                 center: [-75.13901, 39.97085],
                 zoom: 11.62,
@@ -59,6 +61,7 @@ var config = {
             title: 'Indego Bike Share',
             image: '',
             description: 'Indego has been operating in Philadelphia since 20XX. The system initally was focused on Center City, but has expanded service to neighboring areas to support equitable mobility options to the city\'s residents.',
+            mapDescription: 'Zoomed into city center with points showing Indego locations in the city.',
             location: {
                 center: [-75.16468, 39.94503],
                 zoom: 13.15,
@@ -84,6 +87,7 @@ var config = {
             title: 'Belmont Plateau Trails',
             image: '',
             description: 'A short ride along the Schuylkill River Trail from the Art Museum, Belmont is a twisty, log-ridden rollercoaster of a trail network. It is easy to get turned around, the underbrush is at times impenetrable, and short steep sections come out of nowhere. In other words, it\'s really fun',
+            mapDescription: 'View of Belmont Plateau in Philadelphia showing twisting mountain bike trails.',
             location: {
                 center: [-75.20325, 39.99574],
                 zoom: 14.99,
@@ -109,6 +113,7 @@ var config = {
             title: 'Wissahickon Park Trails',
             image: '',
             description: 'This steep, rocky gorge can be surprisingly technical. Follow the orange and yellow trails to repeatedly climb and descend through the schist hillsides (careful of the cliffs), or stick to the gravel Forbidden Drive for a relaxing ride along the creek. You\'ll forget you\'re in a city.',
+            mapDescription: 'Wissahickon park trails highlighted on the map along a valley.',
             location: {
                 center: [-75.21223, 40.05028],
                 zoom: 13.08,
@@ -134,6 +139,7 @@ var config = {
             title: 'Pennypack Park Trails',
             image: '',
             description: 'Pennypack is a great introduction trail system. Not too steep and not too technical, the beautiful wooded park also provides a great escape from urban life. The south side trails are originally bridle trails, so be nice to equestrians and dismount when you approach them.',
+            mapDescription: 'Another valley with bike trails on either side',
             location: {
                 center: [-75.05685, 40.06839],
                 zoom: 13.73,

--- a/example/bike-philly/index.html
+++ b/example/bike-philly/index.html
@@ -95,6 +95,12 @@
             width: 100%;
         }
 
+        #mapDescription {
+            position: fixed;
+            top: 0;
+            z-index: -1;
+        }
+
         @media (max-width: 750px) {
             .centered, .lefty, .righty, .fully {
                 width: 90vw;
@@ -114,6 +120,7 @@
 
 <div id="map"></div>
 <div id="story"></div>
+<div id="mapDescription" aria-live="polite"></div>
 <script src="./config.js"></script>
 <script>
 var layerTypes = {
@@ -239,7 +246,6 @@ mapboxgl.accessToken = config.accessToken;
 const transformRequest = (url) => {
     const hasQuery = url.indexOf("?") !== -1;
     const suffix = hasQuery ? "&pluginName=scrollytellingV2" : "?pluginName=scrollytellingV2";
-
     return {
       url: url + suffix
     }
@@ -298,7 +304,6 @@ map.on("load", function() {
         var chapter = config.chapters.find(chap => chap.id === response.element.id);
         response.element.classList.add('active');
         map[chapter.mapAnimation || 'flyTo'](chapter.location);
-
         if (config.showMarkers) {
             marker.setLngLat(chapter.location.center);
         }
@@ -317,6 +322,10 @@ map.on("load", function() {
                     }
                 });
             });
+        }
+        if (chapter.mapDescription) {
+            mapDescription = document.querySelector("#mapDescription");
+            mapDescription.innerText = "Current map view shows: " + chapter.mapDescription;
         }
     })
     .onStepExit(response => {

--- a/example/glacier/config.js
+++ b/example/glacier/config.js
@@ -15,6 +15,7 @@ var config = {
             title: 'Glacier National Park Glaciers',
             image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/2015-06-19_Glacier_National_Park_%28U.S.%29_8633.jpg/800px-2015-06-19_Glacier_National_Park_%28U.S.%29_8633.jpg',
             description: 'Glacier National Park is dominated by mountains which were carved into their present shapes by the huge glaciers of the last ice age. These glaciers have largely disappeared over the last 12,000 years. Evidence of widespread glacial action is found throughout the park in the form of U-shaped valleys, cirques, arêtes, and large outflow lakes radiating like fingers from the base of the highest peaks. Since the end of the ice ages, various warming and cooling trends have occurred. The last recent cooling trend was during the Little Ice Age, which took place approximately between 1550 and 1850. During the Little Ice Age, the glaciers in the park expanded and advanced, although to nowhere near as great an extent as they had during the Ice Age.',
+            mapDescription: 'Overview of Glacier National Park in Montana. The park is highlighted in green.',
             location: {
                 center: [-113.91666, 48.66451],
                 zoom: 8,
@@ -44,6 +45,7 @@ var config = {
             title: 'Harrison Glacier, 1998',
             image: '',
             description: 'Harrison Glacier is located in the US state of Montana in Glacier National Park. Situated on a southeast facing ridge immediately south of Mount Jackson, Harrison Glacier is the largest glacier in Glacier National Park. Compared to many of the vanishing glaciers in Glacier National Park, Harrison Glacier has a much higher altitude accumulation zone (approximately 9,000 feet (2,700 m)) which has allowed it to maintain some equilibrium in its glacier mass balance.',
+            mapDescription: 'Zoom into a 3D oblique view of Harrison Glacier area, located near the center of the park. Glaical extent from 1998 is shown in light blue',
             location: {
                 center: [-113.72917, 48.58938],
                 zoom: 12.92,
@@ -64,6 +66,7 @@ var config = {
             title: 'Harrison Glacier, 2015',
             image: '',
             description: 'Between 1998 and 2015, Harrison Glacier lost 169 acres of surface area (about 37%).',
+            mapDescription: '2015 extent overlain on top of 1998 extent, showing major decrease in coverage.',
             location: {
                 center: [-113.72917, 48.58938],
                 zoom: 12.92,
@@ -89,6 +92,7 @@ var config = {
             title: 'Blackfoot Glacier, 1998',
             image: '',
             description: 'Blackfoot Glacier is the second largest of the remaining 25 glaciers in Glacier National Park, Montana. Blackfoot Glacier is just to the north of Blackfoot Mountain and near Jackson Glacier. When first documented in 1850, the glacier also included the now separate Jackson Glacier and together, they covered 1,875 acres (7.59 km2). In 1850, there were an estimated 150 glaciers in the park. Glaciologists have stated that by the year 2030, all the glaciers in the park may disappear.',
+            mapDescription: 'Zoom to Blackfoot Glacier, now showing light blue area of the glacier in 1988',
             location: {
                 center: [-113.66573, 48.59181],
                 zoom: 12.92,
@@ -104,6 +108,7 @@ var config = {
             title: 'Blackfoot Glacier, 2015',
             image: '',
             description: 'Between 1998 and 2015, Blackfoot Glacier lost 31 acres of surface area (about 8%).',
+            mapDescription: 'Updated view to show 2015 glacial extent overlain',
             location: {
                 center: [-113.66573, 48.59181],
                 zoom: 12.92,

--- a/example/glacier/index.html
+++ b/example/glacier/index.html
@@ -95,6 +95,12 @@
             width: 100%;
         }
 
+        #mapDescription {
+            position: fixed;
+            top: 0;
+            z-index: -1;
+        }
+
         @media (max-width: 750px) {
             .centered, .lefty, .righty, .fully {
                 width: 90vw;
@@ -114,6 +120,7 @@
 
 <div id="map"></div>
 <div id="story"></div>
+<div id="mapDescription" aria-live="polite"></div>
 <script src="./config.js"></script>
 <script>
 var layerTypes = {
@@ -297,7 +304,6 @@ map.on("load", function() {
         var chapter = config.chapters.find(chap => chap.id === response.element.id);
         response.element.classList.add('active');
         map[chapter.mapAnimation || 'flyTo'](chapter.location);
-
         if (config.showMarkers) {
             marker.setLngLat(chapter.location.center);
         }
@@ -316,6 +322,10 @@ map.on("load", function() {
                     }
                 });
             });
+        }
+        if (chapter.mapDescription) {
+            mapDescription = document.querySelector("#mapDescription");
+            mapDescription.innerText = "Current map view shows: " + chapter.mapDescription;
         }
     })
     .onStepExit(response => {

--- a/src/config.js.template
+++ b/src/config.js.template
@@ -17,6 +17,7 @@ var config = {
             title: 'Display Title',
             image: './path/to/image/source.png',
             description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+            mapDescription: 'For accessibility purposes, briefly explain the current map view at each step for users utilizing screen readers.',
             location: {
                 center: [-122.418398, 37.759483],
                 zoom: 8.5,
@@ -47,6 +48,7 @@ var config = {
             title: 'Second Title',
             image: './path/to/image/source.png',
             description: 'Copy these sections to add to your story.',
+            mapDescription: 'Describe the current map view',
             location: {
                 center: [-77.020636, 38.886900],
                 zoom: 8.5,

--- a/src/index.html
+++ b/src/index.html
@@ -96,7 +96,8 @@
         }
 
         #mapDescription {
-            position: absolute;
+            position: fixed;
+            top: 0;
             z-index: -1;
         }
 
@@ -324,7 +325,7 @@ map.on("load", function() {
         }
         if (chapter.mapDescription) {
             mapDescription = document.querySelector("#mapDescription");
-            mapDescription.innerText = "Current Map View Description: " + chapter.mapDescription
+            mapDescription.innerText = "Current map view shows: " + chapter.mapDescription;
         }
     })
     .onStepExit(response => {

--- a/src/index.html
+++ b/src/index.html
@@ -95,6 +95,11 @@
             width: 100%;
         }
 
+        #mapDescription {
+            position: absolute;
+            z-index: -1;
+        }
+
         @media (max-width: 750px) {
             .centered, .lefty, .righty, .fully {
                 width: 90vw;
@@ -114,6 +119,7 @@
 
 <div id="map"></div>
 <div id="story"></div>
+<div id="mapDescription" aria-live="polite"></div>
 <script src="./config.js"></script>
 <script>
 var layerTypes = {
@@ -315,6 +321,10 @@ map.on("load", function() {
                     }
                 });
             });
+        }
+        if (chapter.mapDescription) {
+            mapDescription = document.querySelector("#mapDescription");
+            mapDescription.innerText = "Current Map View Description: " + chapter.mapDescription
         }
     })
     .onStepExit(response => {


### PR DESCRIPTION
I've made a couple small additions to allow for an optional field describing the current map view to be included for each chapter. This field is used to update a hidden div with `aria-live='polite'` enabled ([more info](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)). This announces the descriptive text to people utilizing screen readers as each chapter comes into view.

I'm not an expert in this area, but this seemed like a fairly simple solution. It's certainly a bit of a hack so if there are better ways or other ideas I would love to learn them! 

Thanks for all the great work on this repo - I see amazing stories utilizing it all over the place.