### PR TITLE
style fixes for #insetMap, hide on smaller viewports, properly hide a…

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,6 +36,14 @@
             transition: opacity 0.5s ease-in-out;
             pointer-events: none;
         }
+        #mapInset .mapboxgl-ctrl-bottom-left{
+            display: none;
+        }
+        @media (max-width: 500px) {
+            #mapInset {
+                display: none;
+            }
+        }
         #header {
             margin: auto;
             width: 100%;


### PR DESCRIPTION
This fixes the inset map display by removing the MAPBOX logo attribution with CSS.  It also accounts for smaller viewports and hides the inset entirely on screens less than 500px.