### PR TITLE
allow clicking through the story to mapbox attribution

### DIFF
--- a/example/bike-philly/index.html
+++ b/example/bike-philly/index.html
@@ -48,6 +48,7 @@
         #features {
             padding-top: 10vh;
             padding-bottom: 10vh;
+            pointer-events: none;
         }
         .hidden {
             visibility: hidden;
@@ -89,6 +90,7 @@
             padding:  25px 50px;
             line-height: 25px;
             font-size: 13px;
+            pointer-events: auto;
         }
 
         .step img {

--- a/example/glacier/index.html
+++ b/example/glacier/index.html
@@ -48,6 +48,7 @@
         #features {
             padding-top: 10vh;
             padding-bottom: 10vh;
+            pointer-events: none;
         }
         .hidden {
             visibility: hidden;
@@ -89,6 +90,7 @@
             padding:  25px 50px;
             line-height: 25px;
             font-size: 13px;
+            pointer-events: auto;
         }
 
         .step img {

--- a/src/index.html
+++ b/src/index.html
@@ -69,6 +69,7 @@
         #features {
             padding-top: 10vh;
             padding-bottom: 10vh;
+            pointer-events: none;
         }
         .hidden {
             visibility: hidden;
@@ -110,6 +111,7 @@
             padding:  25px 50px;
             line-height: 25px;
             font-size: 13px;
+            pointer-events: auto;
         }
 
         .step img {


### PR DESCRIPTION
This was apparently fixed previously (https://github.com/mapbox/storytelling/issues/34) but must have been reverted at some point. 

This is fixed by setting `pointer-events: none;` on `#features` and setting back to `auto` on `.step div` to allow links and other interactivity to still be added to the story. 