### PR TITLE
Remove resize handler since Scrollama handles this internally

### DIFF
--- a/example/bike-philly/index.html
+++ b/example/bike-philly/index.html
@@ -328,9 +328,6 @@ map.on("load", function() {
     });
 });
 
-// setup resize event
-window.addEventListener('resize', scroller.resize);
-
 </script>
 
 </body>

--- a/example/glacier/index.html
+++ b/example/glacier/index.html
@@ -327,9 +327,6 @@ map.on("load", function() {
     });
 });
 
-// setup resize event
-window.addEventListener('resize', scroller.resize);
-
 </script>
 
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -465,11 +465,6 @@ function updateInsetLayer(bounds) {
     insetMap.getSource('boundsSource').setData(bounds);
 }
 
-
-
-// setup resize event
-window.addEventListener('resize', scroller.resize);
-
 </script>
 
 </body>


### PR DESCRIPTION
Was seeing some bugs on mobile related to resize events being fired (when the viewport height changed with hiding/showing the address bar). I noticed that Scrollama now handles resize events internally (https://github.com/russellgoldenberg/scrollama#scrollamaresize).

Removing this extra handler fixed the issues I was seeing without regressions. 